### PR TITLE
Boot fix and RRAM size change

### DIFF
--- a/demo/dfu_sim3/Makefile
+++ b/demo/dfu_sim3/Makefile
@@ -86,8 +86,8 @@ SRC = $(TARGET).c \
 	../../usb/usb.c \
 	../../usb/ctrl.c \
 	../../usb/usb_buf.c \
-	../../class/dfu/desc.c \
-	../../class/dfu/dfu.c 
+	../../class/DFU/desc.c \
+	../../class/DFU/dfu.c
 
 #check which files to load depending on the part type
 ifeq ($(MCU), at90usb162)
@@ -154,7 +154,7 @@ DEBUG = dwarf-2
 #     Each directory must be seperated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
-EXTRAINCDIRS = ../../usb ../../class/dfu
+EXTRAINCDIRS = ../../usb ../../class/DFU
 
 #check which directories to include depending on part type
 ifeq ($(MCU), at90usb162)

--- a/hw/sim3u1xx/hw.c
+++ b/hw/sim3u1xx/hw.c
@@ -559,10 +559,6 @@ void hw_boot_image( int usb_started )
           for( down_count = 0x147AE1; down_count != 0; down_count-- );
         }
 
-        // Set up image entry point function pointer
-        // entry point is 1 word after start of image
-        enter_image = ( void ( * )( void ) )( *( image_base + 1 ) );
-
         // Disable USB Interrupts
         NVIC_DisableIRQ( USB0_IRQn );
 
@@ -571,8 +567,9 @@ void hw_boot_image( int usb_started )
 
         // Configure image stack pointer
         __set_MSP( *image_base );
-
-        enter_image();
+       // Jump to image entry point (which should never return)
+       // entry point is 1 word after start of image
+        asm volatile("mov pc, %[src]" :: [src]"r"(*(image_base + 1)));
     }
 }
 

--- a/hw/sim3u1xx/sim3u1xx.ld
+++ b/hw/sim3u1xx/sim3u1xx.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
     flash (RX) : ORIGIN = 0x00000000, LENGTH = 0x3fffc
 }
 

--- a/hw/sim3u1xx/sim3u1xx_bl.ld
+++ b/hw/sim3u1xx/sim3u1xx_bl.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
     flash (RX) : ORIGIN = 0x00000000, LENGTH = 0x2800
 }
 


### PR DESCRIPTION
This commit fixes an issue that prevented the bootloader to load the
stack pointer properly when booting the image. The previous code:

```
         // Configure image stack pointer
         __set_MSP( *image_base );

         enter_image();
```

resulted in this assembler output:

```
...
        msr MSP, r3 // SP loaded here
...
        add sp, #8  // oops!
        bx  r2      // jump to image
```

Notice that GCC tries to restore the stack before jumping into the image
(`add sp, #8`) which is the expected behavior, but since SP is already set
at the end of RAM (by the firmware image) in `msr MSP, r3`, this will set
SP to a region outside the available RAM, which in turn will trigger a
hard fault right when the firmware image runs (no idea how this ever
worked).

With the new code in place, the assembler output looks like this:

```
...
        msr MSP, r3      // SP loaded here
...
        ldr r3, [r3, #0] // load image address
        mov pc, r3       // jump to image immediately
        add sp, #8       // dead code
        bx  lr           // dead code
```

GCC still tries to clear the stack, but the `add sp, #8` instruction is
never reached because of the previous `mov pc, r3`.

The commit also changes the RRAM size from 32 bytes to 128 bytes. A
separate commit will be needed to the eLua repository to enable this;
also, we need to make sure that the 128-bytes RRAM bootloader is used
only with 128-bytes RRAM firmware images and the other way around
(although a 32-byte RRAM firmware image should also work with an
128-bytes RRAM bootloader, it's probably best to mix and match them
properly to avoid confusion).